### PR TITLE
Allow None in write type annotations for zero-length write requests

### DIFF
--- a/src/pyads/connection.py
+++ b/src/pyads/connection.py
@@ -282,7 +282,7 @@ class Connection(object):
 
     def write(
             self, index_group: int, index_offset: int, value: Any,
-            plc_datatype: Type["PLCDataType"]
+            plc_datatype: Optional[Type["PLCDataType"]]
     ) -> None:
         """Send data synchronous to an ADS-device.
 
@@ -290,8 +290,9 @@ class Connection(object):
             constants
         :param int index_offset: PLC storage address
         :param Any value: value to write to the storage address of the PLC
-        :param Type["PLCDataType"] plc_datatype: type of the data given to the PLC,
-            according to PLCTYPE constants
+        :param Optional[Type["PLCDataType"]] plc_datatype: type of the data given
+            to the PLC, according to PLCTYPE constants. Pass ``None`` to send a
+            zero-length write request (no data buffer).
 
         """
         if self._port is not None:

--- a/src/pyads/pyads_ex.py
+++ b/src/pyads/pyads_ex.py
@@ -605,7 +605,7 @@ def adsSyncWriteReqEx(
     index_group: int,
     index_offset: int,
     value: Any,
-    plc_data_type: Type,
+    plc_data_type: Optional[Type],
 ) -> None:
     """Send data synchronous to an ADS-device.
 
@@ -615,8 +615,9 @@ def adsSyncWriteReqEx(
         constants
     :param int index_offset: PLC storage address
     :param value: value to write to the storage address of the PLC
-    :param int plc_data_type: type of the data given to the PLC,
-        according to PLCTYPE constants
+    :param Optional[Type] plc_data_type: type of the data given to the PLC,
+        according to PLCTYPE constants. Pass ``None`` to send a zero-length
+        write request (no data buffer).
 
     """
     sync_write_request = _adsDLL.AdsSyncWriteReqEx

--- a/tests/test_connection_class.py
+++ b/tests/test_connection_class.py
@@ -263,6 +263,30 @@ class AdsConnectionClassTestCase(unittest.TestCase):
 
         self.assertEqual(value, received_value)
 
+    def test_write_zero_length(self):
+        """Zero-length write request (plc_datatype=None) sends no buffer."""
+        with self.plc:
+            self.plc.write(
+                index_group=constants.INDEXGROUP_DATA,
+                index_offset=1,
+                value=None,
+                plc_datatype=None,
+            )
+
+        # Retrieve list of received requests from server
+        requests = self.test_server.request_history
+
+        # Assert that the server received a request
+        self.assertEqual(len(requests), 1)
+
+        # Assert that the server received the correct command
+        self.assert_command_id(requests[0], constants.ADSCOMMAND_WRITE)
+
+        # The length field must be zero and no value payload should follow
+        data_length = struct.unpack("<I", requests[0].ams_header.data[8:12])[0]
+        self.assertEqual(data_length, 0)
+        self.assertEqual(requests[0].ams_header.data[12:], b"")
+
     def test_write_float(self):
         value = 123.456
 


### PR DESCRIPTION
PR #515 added support for zero-length write requests (plc_data_type=None)
in adsSyncWriteReqEx but did not update the type annotations to reflect that
None is now an accepted value. Update the annotations on adsSyncWriteReqEx
and Connection.write to Optional[Type], and add a test covering the
zero-length write use-case.

https://claude.ai/code/session_01QKx2yv6cnjKgJAeHkU6JEG